### PR TITLE
Use rest api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.7
   - 1.8
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
 
+dist: trusty
+
 go:
   - "1.13"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - "1.9"
-  - "1.10"
+  - "1.10.3"
 
 services:
   - rabbitmq
@@ -18,7 +17,7 @@ before_install:
   - go get -u -ldflags "-s -w" k8s.io/client-go/...
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.10.4 --single-branch -q https://github.com/kubernetes/kubernetes.git $HOME/gopath/src/k8s.io/kubernetes
+  - if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.11.0 --single-branch -q https://github.com/kubernetes/kubernetes $(GOPATH)/src/k8s.io/kubernetes
 
 script:
   - go test -v -covermode=count -coverprofile=cover.out --tags=integration ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - go get -u -ldflags "-s -w" k8s.io/client-go/...
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.11.3 --single-branch -q https://github.com/kubernetes/kubernetes $HOME/gopath/src/k8s.io/kubernetes
+  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.12.1 --single-branch -q https://github.com/kubernetes/kubernetes $HOME/gopath/src/k8s.io/kubernetes
 
 script:
   - go test -v -covermode=count -coverprofile=cover.out --tags=integration ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 
 go:
   - 1.9
-  - 1.10
 
 services:
   - rabbitmq

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - 1.9
+  - "1.9"
+  - "1.10"
 
 services:
   - rabbitmq
@@ -17,7 +18,7 @@ before_install:
   - go get -u -ldflags "-s -w" k8s.io/client-go/...
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.9.3 --single-branch -q https://github.com/kubernetes/kubernetes.git $HOME/gopath/src/k8s.io/kubernetes
+  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.10.1 --single-branch -q https://github.com/kubernetes/kubernetes.git $HOME/gopath/src/k8s.io/kubernetes
 
 script:
   - go test -v -covermode=count -coverprofile=cover.out --tags=integration ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - go get -u -ldflags "-s -w" k8s.io/client-go/...
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.12.1 --single-branch -q https://github.com/kubernetes/kubernetes $HOME/gopath/src/k8s.io/kubernetes
+  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.12.2 --single-branch -q https://github.com/kubernetes/kubernetes $HOME/gopath/src/k8s.io/kubernetes
 
 script:
   - go test -v -covermode=count -coverprofile=cover.out --tags=integration ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
   - 1.9
+  - 1.10
 
 services:
   - rabbitmq
@@ -15,7 +16,7 @@ before_install:
   - go get -u -ldflags "-s -w" github.com/streadway/amqp
   - go get -u -ldflags "-s -w" github.com/mattn/go-sqlite3
   - go get -u -ldflags "-s -w" k8s.io/client-go/...
-  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.7.8 --single-branch -q https://github.com/kubernetes/kubernetes.git $HOME/gopath/src/k8s.io/kubernetes
+  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.9.3 --single-branch -q https://github.com/kubernetes/kubernetes.git $HOME/gopath/src/k8s.io/kubernetes
 
 script:
   - go test -v -covermode=count -coverprofile=cover.out --tags=integration ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.11"
+  - "1.12"
 
 services:
   - rabbitmq
@@ -17,7 +17,7 @@ before_install:
   - go get -u -ldflags "-s -w" k8s.io/client-go/...
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.12.2 --single-branch -q https://github.com/kubernetes/kubernetes $HOME/gopath/src/k8s.io/kubernetes
+  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.14.1 --single-branch -q https://github.com/kubernetes/kubernetes $HOME/gopath/src/k8s.io/kubernetes
 
 script:
   - go test -v -covermode=count -coverprofile=cover.out --tags=integration ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.10.3"
+  - "1.11"
 
 services:
   - rabbitmq
@@ -17,7 +17,7 @@ before_install:
   - go get -u -ldflags "-s -w" k8s.io/client-go/...
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.11.0 --single-branch -q https://github.com/kubernetes/kubernetes $HOME/gopath/src/k8s.io/kubernetes
+  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.11.2 --single-branch -q https://github.com/kubernetes/kubernetes $HOME/gopath/src/k8s.io/kubernetes
 
 script:
   - go test -v -covermode=count -coverprofile=cover.out --tags=integration ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.12"
+  - "1.13"
 
 services:
   - rabbitmq
@@ -14,10 +14,11 @@ before_install:
   - go get -u -buildmode=exe -ldflags "-s -w" github.com/mattn/goveralls
   - go get -u -ldflags "-s -w" github.com/streadway/amqp
   - go get -u -ldflags "-s -w" github.com/mattn/go-sqlite3
+  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v0.4.0 --single-branch -q https://github.com/kubernetes/klog $HOME/gopath/src/k8s.io/klog
   - go get -u -ldflags "-s -w" k8s.io/client-go/...
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.14.1 --single-branch -q https://github.com/kubernetes/kubernetes $HOME/gopath/src/k8s.io/kubernetes
+  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.15.3 --single-branch -q https://github.com/kubernetes/kubernetes $HOME/gopath/src/k8s.io/kubernetes
 
 script:
   - go test -v -covermode=count -coverprofile=cover.out --tags=integration ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ before_install:
   - go get -u -ldflags "-s -w" github.com/streadway/amqp
   - go get -u -ldflags "-s -w" github.com/mattn/go-sqlite3
   - go get -u -ldflags "-s -w" k8s.io/client-go/...
+  - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
+  - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
   - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.9.3 --single-branch -q https://github.com/kubernetes/kubernetes.git $HOME/gopath/src/k8s.io/kubernetes
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - go get -u -ldflags "-s -w" k8s.io/client-go/...
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-  - if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.11.0 --single-branch -q https://github.com/kubernetes/kubernetes $(GOPATH)/src/k8s.io/kubernetes
+  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.11.0 --single-branch -q https://github.com/kubernetes/kubernetes.git $HOME/gopath/src/k8s.io/kubernetes
 
 script:
   - go test -v -covermode=count -coverprofile=cover.out --tags=integration ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - go get -u -ldflags "-s -w" k8s.io/client-go/...
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.11.2 --single-branch -q https://github.com/kubernetes/kubernetes $HOME/gopath/src/k8s.io/kubernetes
+  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.11.3 --single-branch -q https://github.com/kubernetes/kubernetes $HOME/gopath/src/k8s.io/kubernetes
 
 script:
   - go test -v -covermode=count -coverprofile=cover.out --tags=integration ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - go get -u -ldflags "-s -w" k8s.io/client-go/...
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.10.1 --single-branch -q https://github.com/kubernetes/kubernetes.git $HOME/gopath/src/k8s.io/kubernetes
+  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.10.4 --single-branch -q https://github.com/kubernetes/kubernetes.git $HOME/gopath/src/k8s.io/kubernetes
 
 script:
   - go test -v -covermode=count -coverprofile=cover.out --tags=integration ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - go get -u -ldflags "-s -w" k8s.io/client-go/...
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
   - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.11.0 --single-branch -q https://github.com/kubernetes/kubernetes.git $HOME/gopath/src/k8s.io/kubernetes
+  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.11.0 --single-branch -q https://github.com/kubernetes/kubernetes $HOME/gopath/src/k8s.io/kubernetes
 
 script:
   - go test -v -covermode=count -coverprofile=cover.out --tags=integration ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - go get -u -ldflags "-s -w" github.com/streadway/amqp
   - go get -u -ldflags "-s -w" github.com/mattn/go-sqlite3
   - go get -u -ldflags "-s -w" k8s.io/client-go/...
-  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.6.2 --single-branch -q https://github.com/kubernetes/kubernetes.git $HOME/gopath/src/k8s.io/kubernetes
+  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.7.2 --single-branch -q https://github.com/kubernetes/kubernetes.git $HOME/gopath/src/k8s.io/kubernetes
 
 script:
   - go test -v -covermode=count -coverprofile=cover.out --tags=integration ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.8
+  - 1.9
 
 services:
   - rabbitmq
@@ -15,7 +15,7 @@ before_install:
   - go get -u -ldflags "-s -w" github.com/streadway/amqp
   - go get -u -ldflags "-s -w" github.com/mattn/go-sqlite3
   - go get -u -ldflags "-s -w" k8s.io/client-go/...
-  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.7.2 --single-branch -q https://github.com/kubernetes/kubernetes.git $HOME/gopath/src/k8s.io/kubernetes
+  - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.7.8 --single-branch -q https://github.com/kubernetes/kubernetes.git $HOME/gopath/src/k8s.io/kubernetes
 
 script:
   - go test -v -covermode=count -coverprofile=cover.out --tags=integration ./...

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ depend:
 	go get -u -ldflags "-s -w" github.com/streadway/amqp
 	go get -u -ldflags "-s -w" github.com/mattn/go-sqlite3
 	go get -u -ldflags "-s -w" k8s.io/client-go/...
-	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.7.2 --single-branch -q https://github.com/kubernetes/kubernetes.git $(GOPATH)/src/k8s.io/kubernetes
+	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.7.8 --single-branch -q https://github.com/kubernetes/kubernetes.git $(GOPATH)/src/k8s.io/kubernetes
 
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ depend:
 	go get -u -ldflags "-s -w" k8s.io/client-go/...
 	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
 	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.12.1 --single-branch -q https://github.com/kubernetes/kubernetes $(GOPATH)/src/k8s.io/kubernetes
+	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.12.2 --single-branch -q https://github.com/kubernetes/kubernetes $(GOPATH)/src/k8s.io/kubernetes
 
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ depend:
 	go get -u -ldflags "-s -w" github.com/streadway/amqp
 	go get -u -ldflags "-s -w" github.com/mattn/go-sqlite3
 	go get -u -ldflags "-s -w" k8s.io/client-go/...
+	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
+	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
 	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.9.3 --single-branch -q https://github.com/kubernetes/kubernetes.git $(GOPATH)/src/k8s.io/kubernetes
 
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ depend:
 	go get -u -ldflags "-s -w" k8s.io/client-go/...
 	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
 	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.11.0 --single-branch -q https://github.com/kubernetes/kubernetes $(GOPATH)/src/k8s.io/kubernetes
+	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.11.2 --single-branch -q https://github.com/kubernetes/kubernetes $(GOPATH)/src/k8s.io/kubernetes
 
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ depend:
 	go get -u -ldflags "-s -w" k8s.io/client-go/...
 	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
 	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.10.1 --single-branch -q https://github.com/kubernetes/kubernetes.git $(GOPATH)/src/k8s.io/kubernetes
+	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.10.4 --single-branch -q https://github.com/kubernetes/kubernetes.git $(GOPATH)/src/k8s.io/kubernetes
 
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ depend:
 	go get -u -ldflags "-s -w" k8s.io/client-go/...
 	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
 	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.12.2 --single-branch -q https://github.com/kubernetes/kubernetes $(GOPATH)/src/k8s.io/kubernetes
+	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.12.7 --single-branch -q https://github.com/kubernetes/kubernetes $(GOPATH)/src/k8s.io/kubernetes
 
 
 install:
@@ -52,4 +52,4 @@ test:
 	go test -v ./...
 
 vet:
-	go tool vet -all -shadow *.go
+	go vet -all *.go

--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,11 @@ if [ -d $(DIST_DIR) ] ; then rm -rf $(DIST_DIR) ; fi
 depend:
 	go get -u -ldflags "-s -w" github.com/streadway/amqp
 	go get -u -ldflags "-s -w" github.com/mattn/go-sqlite3
+	if [ -d $(GOPATH)/src/k8s.io/klog ] ; then rm -rf $(GOPATH)/src/k8s.io/klog ; fi && git clone --depth 1 -b v0.4.0 --single-branch -q https://github.com/kubernetes/klog $(GOPATH)/src/k8s.io/klog
 	go get -u -ldflags "-s -w" k8s.io/client-go/...
 	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
 	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.12.7 --single-branch -q https://github.com/kubernetes/kubernetes $(GOPATH)/src/k8s.io/kubernetes
+	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.15.3 --single-branch -q https://github.com/kubernetes/kubernetes $(GOPATH)/src/k8s.io/kubernetes
 
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ depend:
 	go get -u -ldflags "-s -w" k8s.io/client-go/...
 	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
 	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.10.4 --single-branch -q https://github.com/kubernetes/kubernetes.git $(GOPATH)/src/k8s.io/kubernetes
+	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.11.0 --single-branch -q https://github.com/kubernetes/kubernetes $(GOPATH)/src/k8s.io/kubernetes
 
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ depend:
 	go get -u -ldflags "-s -w" k8s.io/client-go/...
 	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
 	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.11.3 --single-branch -q https://github.com/kubernetes/kubernetes $(GOPATH)/src/k8s.io/kubernetes
+	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.12.1 --single-branch -q https://github.com/kubernetes/kubernetes $(GOPATH)/src/k8s.io/kubernetes
 
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ depend:
 	go get -u -ldflags "-s -w" k8s.io/client-go/...
 	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
 	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.9.3 --single-branch -q https://github.com/kubernetes/kubernetes.git $(GOPATH)/src/k8s.io/kubernetes
+	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.10.1 --single-branch -q https://github.com/kubernetes/kubernetes.git $(GOPATH)/src/k8s.io/kubernetes
 
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ depend:
 	go get -u -ldflags "-s -w" k8s.io/client-go/...
 	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
 	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
-	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.11.2 --single-branch -q https://github.com/kubernetes/kubernetes $(GOPATH)/src/k8s.io/kubernetes
+	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.11.3 --single-branch -q https://github.com/kubernetes/kubernetes $(GOPATH)/src/k8s.io/kubernetes
 
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ depend:
 	go get -u -ldflags "-s -w" github.com/streadway/amqp
 	go get -u -ldflags "-s -w" github.com/mattn/go-sqlite3
 	go get -u -ldflags "-s -w" k8s.io/client-go/...
-	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.7.8 --single-branch -q https://github.com/kubernetes/kubernetes.git $(GOPATH)/src/k8s.io/kubernetes
+	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.9.3 --single-branch -q https://github.com/kubernetes/kubernetes.git $(GOPATH)/src/k8s.io/kubernetes
 
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ depend:
 	go get -u -ldflags "-s -w" github.com/streadway/amqp
 	go get -u -ldflags "-s -w" github.com/mattn/go-sqlite3
 	go get -u -ldflags "-s -w" k8s.io/client-go/...
-	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.6.2 --single-branch -q https://github.com/kubernetes/kubernetes.git $(GOPATH)/src/k8s.io/kubernetes
+	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.7.2 --single-branch -q https://github.com/kubernetes/kubernetes.git $(GOPATH)/src/k8s.io/kubernetes
 
 
 install:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Run `make depend && make [build]`
 ## Runtime command-line arguments
 
 * **`amqp-uri`** required, RabbitMQ broker URI, e.g. `amqp://guest:guest@127.0.0.1:5672//`
-* **`amqp-queue`** required, RabbitMQ queue name to measure load on an application
+* **`amqp-queue`** required, RabbitMQ queue name to measure load on an application.  Use comma separator to specify multiple queues.
 * **`api-url`** required, Kubernetes API URL, e.g. `http://127.0.0.1:8080`
 * `api-user` optional, username for basic authentication on Kubernetes API
 * `api-passwd` optional, password for basic authentication on Kubernetes API
@@ -73,9 +73,10 @@ Run `make depend && make [build]`
 * `stats-interval` time interval between metrics gathering runs in seconds (default `5`)
 * `eval-intervals` number of autoscale intervals used to calculate average queue length (default `2`)
 * `stats-coverage` required percentage of statistics to calculate average queue length (default `0.75`)
-* `db` sqlite3 database filename for storing  queue length statistics (default `:memory:`)
+* `db` sqlite3 database filename for storing  queue length statistics (default `file::memory:?cache=shared`)
 * `db-dir` directory for sqlite3 statistics database file
 * `version` show version
+* `metrics-listen-address` the address to listen on for exporting Prometheus metrics (default `:9505`)
 
 
 ## Integration tests

--- a/actuator.go
+++ b/actuator.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"time"
+	"math"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -81,7 +82,7 @@ func (ctx *scaleContext) newSize(avg float64, cov float64) (int32, error) {
 	if cov < ctx.Coverage {
 		err = fmt.Errorf("not enough metrics to calculate new size, required at least %.2f was %.2f metrics ratio", ctx.Coverage, cov)
 	} else {
-		replicas = int32(avg / float64(ctx.Threshold))
+		replicas = int32(math.Ceil(avg / float64(ctx.Threshold)))
 	}
 	return replicas, err
 }

--- a/actuator.go
+++ b/actuator.go
@@ -79,7 +79,7 @@ func (ctx *scaleContext) newSize(avg float64, cov float64) (int32, error) {
 	var replicas int32
 	var err error
 	if cov < ctx.Coverage {
-		err = fmt.Errorf("Not enough metrics to calculate new size, required at least %.2f was %.2f metrics ratio", ctx.Coverage, cov)
+		err = fmt.Errorf("not enough metrics to calculate new size, required at least %.2f was %.2f metrics ratio", ctx.Coverage, cov)
 	} else {
 		replicas = int32(avg / float64(ctx.Threshold))
 	}

--- a/actuator_test.go
+++ b/actuator_test.go
@@ -27,7 +27,7 @@ func TestNewSize(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := s, int32(2); got != want {
+	if got, want := s, int32(3); got != want {
 		t.Errorf("Expected %d, got: %d", want, got)
 	}
 }

--- a/actuator_test.go
+++ b/actuator_test.go
@@ -16,7 +16,7 @@ func TestNewSizeNoCoverage(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error")
 	}
-	if got, want := err.Error(), "Not enough metrics to calculate new size, required at least 0.75 was 0.50 metrics ratio"; got != want {
+	if got, want := err.Error(), "not enough metrics to calculate new size, required at least 0.75 was 0.50 metrics ratio"; got != want {
 		t.Errorf("Expected %s, got: %s", want, got)
 	}
 }

--- a/kube.go
+++ b/kube.go
@@ -57,12 +57,12 @@ func scaleKind(c *kubernetes.Clientset, kind string, ns string, name string, new
 }
 
 func scaleDeployments(c *kubernetes.Clientset, ns string, name string, newSize int32, b *scaleBounds) error {
-	deployment, err := c.AppsV1beta1().Deployments(ns).Get(name, v1.GetOptions{})
+	deployment, err := c.AppsV1beta2().Deployments(ns).Get(name, v1.GetOptions{})
 	replicas := b.newSize(*deployment.Spec.Replicas, newSize)
 	if replicas != *deployment.Spec.Replicas {
 		log.Printf("Scaling deployment '%s' from %d to %d replicas", name, deployment.Spec.Replicas, replicas)
 		deployment.Spec.Replicas = &replicas
-		_, err = c.AppsV1beta1().Deployments(ns).Update(deployment)
+		_, err = c.AppsV1beta2().Deployments(ns).Update(deployment)
 		if err != nil {
 			return err
 		}
@@ -88,7 +88,7 @@ func scaleReplicationControllers(c *kubernetes.Clientset, ns string, name string
 }
 
 func scaleReplicaSets(c *kubernetes.Clientset, ns string, name string, newSize int32, b *scaleBounds) error {
-	pod, err := c.ReplicaSets(ns).Get(name, v1.GetOptions{})
+	pod, err := c.AppsV1beta2().ReplicaSets(ns).Get(name, v1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func scaleReplicaSets(c *kubernetes.Clientset, ns string, name string, newSize i
 	if replicas != *pod.Spec.Replicas {
 		log.Printf("Scaling replica set '%s' from %d to %d replicas", name, pod.Spec.Replicas, replicas)
 		pod.Spec.Replicas = &replicas
-		_, err = c.ReplicaSets(ns).Update(pod)
+		_, err = c.AppsV1beta2().ReplicaSets(ns).Update(pod)
 		if err != nil {
 			return err
 		}

--- a/kube.go
+++ b/kube.go
@@ -46,8 +46,6 @@ func scale(kind string, ns string, name string, newSize int32, ctx *apiContext) 
 
 func scaleKind(c *kubernetes.Clientset, kind string, ns string, name string, newSize int32, b *scaleBounds) error {
 	switch kind {
-	case replicationControllerKind:
-		return scaleReplicationControllers(c, ns, name, newSize, b)
 	case replicaSetKind:
 		return scaleReplicaSets(c, ns, name, newSize, b)
 	case deploymentKind:
@@ -63,23 +61,6 @@ func scaleDeployments(c *kubernetes.Clientset, ns string, name string, newSize i
 		log.Printf("Scaling deployment '%s' from %d to %d replicas", name, deployment.Spec.Replicas, replicas)
 		deployment.Spec.Replicas = &replicas
 		_, err = c.AppsV1beta2().Deployments(ns).Update(deployment)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func scaleReplicationControllers(c *kubernetes.Clientset, ns string, name string, newSize int32, b *scaleBounds) error {
-	pod, err := c.ReplicationControllers(ns).Get(name, v1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	replicas := b.newSize(*pod.Spec.Replicas, newSize)
-	if replicas != *pod.Spec.Replicas {
-		log.Printf("Scaling replication controller '%s' from %d to %d replicas", name, pod.Spec.Replicas, replicas)
-		pod.Spec.Replicas = &replicas
-		_, err = c.ReplicationControllers(ns).Update(pod)
 		if err != nil {
 			return err
 		}

--- a/kube.go
+++ b/kube.go
@@ -20,7 +20,6 @@ import (
 
 const (
 	deploymentKind            = "Deployment"
-	jobKind                   = "Job"
 	replicationControllerKind = "ReplicationController"
 	replicaSetKind            = "ReplicaSet"
 )

--- a/kube.go
+++ b/kube.go
@@ -72,7 +72,7 @@ func scaleDeployments(c *kubernetes.Clientset, ns string, name string, newSize i
 	}
 	replicas := b.newSize(*deployment.Spec.Replicas, newSize)
 	if replicas != *deployment.Spec.Replicas {
-		log.Printf("Scaling deployment '%s' from %d to %d replicas", name, deployment.Spec.Replicas, replicas)
+		log.Printf("Scaling deployment '%s' from %d to %d replicas", name, *deployment.Spec.Replicas, replicas)
 		scalingEvents.With(prometheus.Labels{"kind": "Deployment", "name": name}).Inc()
 		deployment.Spec.Replicas = &replicas
 		_, err = c.AppsV1beta2().Deployments(ns).Update(deployment)
@@ -90,7 +90,7 @@ func scaleReplicaSets(c *kubernetes.Clientset, ns string, name string, newSize i
 	}
 	replicas := b.newSize(*pod.Spec.Replicas, newSize)
 	if replicas != *pod.Spec.Replicas {
-		log.Printf("Scaling replica set '%s' from %d to %d replicas", name, pod.Spec.Replicas, replicas)
+		log.Printf("Scaling replica set '%s' from %d to %d replicas", name, *pod.Spec.Replicas, replicas)
 		scalingEvents.With(prometheus.Labels{"kind": "ReplicaSet", "name": name}).Inc()
 		pod.Spec.Replicas = &replicas
 		_, err = c.AppsV1beta2().ReplicaSets(ns).Update(pod)

--- a/kube.go
+++ b/kube.go
@@ -14,6 +14,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	certutil "k8s.io/client-go/util/cert"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -22,6 +23,17 @@ const (
 	jobKind                   = "Job"
 	replicationControllerKind = "ReplicationController"
 	replicaSetKind            = "ReplicaSet"
+)
+
+var (
+	scalingEvents = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "scaling_events_total",
+			Help:      "Count of scaling events by resource kind.",
+		},
+		[]string{"kind", "name"},
+	)
 )
 
 type apiContext struct {
@@ -62,6 +74,7 @@ func scaleDeployments(c *kubernetes.Clientset, ns string, name string, newSize i
 	replicas := b.newSize(*deployment.Spec.Replicas, newSize)
 	if replicas != *deployment.Spec.Replicas {
 		log.Printf("Scaling deployment '%s' from %d to %d replicas", name, deployment.Spec.Replicas, replicas)
+		scalingEvents.With(prometheus.Labels{"kind": "Deployment", "name": name}).Inc()
 		deployment.Spec.Replicas = &replicas
 		_, err = c.AppsV1beta2().Deployments(ns).Update(deployment)
 		if err != nil {
@@ -79,6 +92,7 @@ func scaleReplicaSets(c *kubernetes.Clientset, ns string, name string, newSize i
 	replicas := b.newSize(*pod.Spec.Replicas, newSize)
 	if replicas != *pod.Spec.Replicas {
 		log.Printf("Scaling replica set '%s' from %d to %d replicas", name, pod.Spec.Replicas, replicas)
+		scalingEvents.With(prometheus.Labels{"kind": "ReplicaSet", "name": name}).Inc()
 		pod.Spec.Replicas = &replicas
 		_, err = c.AppsV1beta2().ReplicaSets(ns).Update(pod)
 		if err != nil {

--- a/kube.go
+++ b/kube.go
@@ -56,6 +56,9 @@ func scaleKind(c *kubernetes.Clientset, kind string, ns string, name string, new
 
 func scaleDeployments(c *kubernetes.Clientset, ns string, name string, newSize int32, b *scaleBounds) error {
 	deployment, err := c.AppsV1beta2().Deployments(ns).Get(name, v1.GetOptions{})
+	if err != nil {
+		return err
+	}
 	replicas := b.newSize(*deployment.Spec.Replicas, newSize)
 	if replicas != *deployment.Spec.Replicas {
 		log.Printf("Scaling deployment '%s' from %d to %d replicas", name, deployment.Spec.Replicas, replicas)

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func init() {
 	flag.IntVar(&statsIntervalParam, "stats-interval", 5, "time interval between metrics gathering runs in seconds")
 	flag.IntVar(&evalIntervalsParam, "eval-intervals", 2, "number of autoscale intervals used to calculate average queue length")
 	flag.Float64Var(&statsCoverageParam, "stats-coverage", 0.75, "required percentage of statistics to calculate average queue length")
-	flag.StringVar(&dbFileParam, "db", ":memory:", "sqlite3 database filename")
+	flag.StringVar(&dbFileParam, "db", "file::memory:?cache=shared", "sqlite3 database filename")
 	flag.StringVar(&dbDirParam, "db-dir", "", "directory for sqlite3 statistics database file")
 
 	flag.BoolVar(&version, "version", false, "show version")

--- a/main.go
+++ b/main.go
@@ -256,7 +256,7 @@ func main() {
 			IncreaseLimit: increaseLimitParam,
 			DecreaseLimit: decreaseLimitParam}
 		return scale(kindParam, namespaceParam, nameParam, newSize,
-			&apiContext{URL: apiURLParam,
+			&apiContext{URL: unquoteURI(apiURLParam),
 				User:      apiUserParam,
 				Passwd:    apiPasswdParam,
 				TokenFile: apiTokenParam,

--- a/main.go
+++ b/main.go
@@ -238,7 +238,7 @@ func main() {
 
 	queueNames := strings.Split(queueNameParam, ",")
 	log.Printf("Summing over %d queues: %s", len(queueNames), queueNameParam)
-	go monitorQueue(brokerURIParam, queueNames, statsIntervalParam, fsample, forever)
+	go monitorQueue(unquoteURI(brokerURIParam), queueNames, statsIntervalParam, fsample, forever)
 
 	fmetrics := func() (*queueMetrics, error) {
 		metrics, err := getMetrics(db, duration, statsIntervalParam)

--- a/metrics.go
+++ b/metrics.go
@@ -28,18 +28,18 @@ func dbPath(dir string, file string) (string, error) {
 		return file, nil
 	}
 	if dir == "" || file == "" {
-		return "", errors.New("Missing directory and/or filename for the metrics database")
+		return "", errors.New("missing directory and/or filename for the metrics database")
 	}
 	fi, err := os.Stat(dir)
 	if err != nil {
 		return "", err
 	}
 	if !fi.IsDir() {
-		return "", fmt.Errorf("Valid directory name is required, got '%s'", dir)
+		return "", fmt.Errorf("valid directory name is required, got '%s'", dir)
 	}
 	filename := filepath.Join(dir, file)
 	if !isValidFile(filename) {
-		return "", fmt.Errorf("Invalid database filename '%s'", filename)
+		return "", fmt.Errorf("invalid database filename '%s'", filename)
 	}
 	return filename, nil
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -30,7 +30,7 @@ func TestDbPathNoFileDir(t *testing.T) {
 	if err == nil {
 		t.Fatal("Error expected")
 	}
-	if got, want := err.Error(), "Missing directory and/or filename for the metrics database"; got != want {
+	if got, want := err.Error(), "missing directory and/or filename for the metrics database"; got != want {
 		t.Errorf("Expected dbPath='%s', got: '%s'", want, got)
 	}
 }

--- a/url.go
+++ b/url.go
@@ -1,0 +1,11 @@
+package main
+
+func unquoteURI(uri string) string {
+	if len(uri) > 0 && (uri[0] == '\'' || uri[0] == '"') {
+		uri = uri[1:]
+	}
+	if len(uri) > 0 && (uri[len(uri)-1] == '\'' || uri[len(uri)-1] == '"') {
+		uri = uri[:len(uri)-1]
+	}
+	return uri
+}

--- a/url_test.go
+++ b/url_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"github.com/streadway/amqp"
+	"testing"
+)
+
+func TestUnquoteURI_localhost_ipv4(t *testing.T) {
+	uri := "amqp://guest:guest@127.0.0.1:5672//"
+	_, err := amqp.ParseURI(unquoteURI(uri))
+	if err != nil {
+		t.Errorf(err.Error(), err)
+	}
+}
+
+func TestUnquoteURI_localhost_ipv6(t *testing.T) {
+	uri := "amqp://guest:guest@[::1]:5672//"
+	_, err := amqp.ParseURI(unquoteURI(uri))
+	if err != nil {
+		t.Errorf(err.Error(), err)
+	}
+}
+
+func TestUnquoteURI_localhost(t *testing.T) {
+	uri := "amqp://guest:guest@localhost:5672//"
+	_, err := amqp.ParseURI(unquoteURI(uri))
+	if err != nil {
+		t.Errorf(err.Error(), err)
+	}
+}
+
+func TestUnquoteURI_localhost_quoted(t *testing.T) {
+	uri := "'amqp://guest:guest@localhost:5672//'"
+	_, err := amqp.ParseURI(unquoteURI(uri))
+	if err != nil {
+		t.Errorf(err.Error(), err)
+	}
+}
+
+func TestUnquoteURI_localhost_ipv4_quoted(t *testing.T) {
+	uri := "'amqp://guest:guest@127.0.0.1:5672//'"
+	_, err := amqp.ParseURI(unquoteURI(uri))
+	if err != nil {
+		t.Errorf(err.Error(), err)
+	}
+}
+
+func TestUnquoteURI_localhost_ipv6_quoted(t *testing.T) {
+	uri := "'amqp://guest:guest@[::1]:5672//'"
+	_, err := amqp.ParseURI(unquoteURI(uri))
+	if err != nil {
+		t.Errorf(err.Error(), err)
+	}
+}
+
+func TestUnquoteURI_localhost_doublequoted(t *testing.T) {
+	uri := "\"amqp://guest:guest@localhost:5672//\""
+	_, err := amqp.ParseURI(unquoteURI(uri))
+	if err != nil {
+		t.Errorf(err.Error(), err)
+	}
+}
+
+func TestUnquoteURI_localhost_ipv4_doublequoted(t *testing.T) {
+	uri := "\"amqp://guest:guest@127.0.0.1:5672//\""
+	_, err := amqp.ParseURI(unquoteURI(uri))
+	if err != nil {
+		t.Errorf(err.Error(), err)
+	}
+}
+
+func TestUnquoteURI_localhost_ipv6_doublequoted(t *testing.T) {
+	uri := "\"amqp://guest:guest@[::1]:5672//\""
+	_, err := amqp.ParseURI(unquoteURI(uri))
+	if err != nil {
+		t.Errorf(err.Error(), err)
+	}
+}


### PR DESCRIPTION
This PR enables to use Rabbit rest API

Usage example: `--amqp-uri=http://guest:guest@127.0.0.1:8080/%2`

Main problem: Currently QueueInspect does not return messages with unacknowledged status.
So if my queue has 5 unacknowledged messages and 5 consumers and my kube-amqp-autoscale with max=10, min=1. QueueInspect will return 0, then kube-amqp-autoscale will decrease my pod number to 1, pods will be killed the messages will be re-enqueue and all cycle starts again 

Rest API queue information return messages with a total of messages (all status) so works better

Plus: The AMQP still working fine, APIRest is another option :)